### PR TITLE
ImportBuddy Log Cleaning improvements

### DIFF
--- a/tools/ImportBuddy/source/ImportBuddy/ImportBuddy/Program.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/ImportBuddy/Program.cs
@@ -48,7 +48,7 @@ static IHostBuilder CreateHostBuilder(string[] args) =>
                 config.AddJsonFile("appsettings.json", optional: false);
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    config.AddJsonFile("appSettings.linux.json", optional: false);
+                    config.AddJsonFile("appsettings.linux.json", optional: false);
                 }
             })
             .ConfigureLogging(logging =>

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/CsvEnumerator.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/CsvEnumerator.cs
@@ -1,0 +1,77 @@
+namespace MakeMkv;
+
+/// <summary>
+/// Iterates over comma separated values in a single line of text. 
+/// </summary>
+public sealed class CsvEnumerator
+{
+    private readonly String _span;
+
+    private readonly Boolean _isInitialized;
+
+    private Int32 _currentStart;
+    private Int32 _currentEnd;
+
+    /// <inheritdoc cref="IEnumerator{T}.Current" />
+    public ReadOnlySpan<Char> Current => _span.AsSpan()[_currentStart.._currentEnd];
+
+    /// <summary>
+    /// Creates a new <see cref="CsvEnumerator"/> over a span of characters.
+    /// </summary>
+    public CsvEnumerator(String span)
+    {
+        _isInitialized = true;
+        _span = span;
+        _currentStart = 0;
+        _currentEnd = -1;
+    }
+    
+    /// <inheritdoc cref="IEnumerator{T}.MoveNext" />
+    public Boolean MoveNext()
+    {
+        Int32 start = _currentEnd + 1;
+        if (!_isInitialized || start > _span.Length)
+            return false;
+
+        var slice = _span[start..];
+        _currentStart = start;
+
+        Boolean quoted = false;
+        Boolean escaped = false;
+        Int32 i;
+        for (i = 0; i < slice.Length; i++)
+        {
+            Char curChar = slice[i];
+            if (curChar == '\\')
+            {
+                if (!escaped)
+                {
+                    escaped = true;
+                    continue;
+                }
+            }
+            else if (curChar == '"')
+            {
+                if (!escaped)
+                    quoted = !quoted;
+            }
+            else if (curChar == ',')
+            {
+                if (!quoted)
+                    break;
+            }
+
+            escaped = false;
+        }
+
+        Int32 elementLength = i;
+
+        _currentEnd = _currentStart + elementLength;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns an enumerator suitable for use in foreach loops.
+    /// </summary>
+    public CsvEnumerator GetEnumerator() => this;
+}

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/CsvEnumerator.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/CsvEnumerator.cs
@@ -74,4 +74,86 @@ public sealed class CsvEnumerator
     /// Returns an enumerator suitable for use in foreach loops.
     /// </summary>
     public CsvEnumerator GetEnumerator() => this;
+
+    /// <summary>
+    /// Attempts to advance the enumerator and parse the value as an <see cref="int"/>.
+    /// </summary>
+    /// <returns>The parsed value, or the <see langword="default"/> value if enumeration or parsing failed.</returns>
+    public int TryParseInt()
+    {
+        if (MoveNext())
+        {
+            if (Int32.TryParse(Current, out int val))
+            {
+                return val;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Attempts to advance the enumerator and parse the value as a <see cref="bool"/>.
+    /// </summary>
+    /// <returns>The parsed value, or <see langword="false"/> if enumeration or parsing failed.</returns>
+    public bool TryParseBoolean()
+    {
+        if (MoveNext())
+        {
+            if (Int32.TryParse(Current, out int val))
+            {
+                return val != 256 && val != 999 && val > 0;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Attempts to advance the enumerator and parse the value as a <see cref="long"/>.
+    /// </summary>
+    /// <returns>The parsed value, or <see langword="null"/> if enumeration or parsing failed.</returns>
+    public string? GetString()
+    {
+        if (MoveNext())
+        {
+            return Current.ToString().Replace("\"", string.Empty);
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Attempts to advance the enumerator and parse the value as a <see cref="DateTime"/>.
+    /// </summary>
+    /// <returns>The parsed value, or the <see langword="default"/> value if enumeration or parsing failed.</returns>
+    public DateTime TryParseDateTime()
+    {
+        if (MoveNext())
+        {
+            if (DateTime.TryParse(Current, out DateTime val))
+            {
+                return val;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Attempts to advance the enumerator and parse the value as a <see cref="long"/>.
+    /// </summary>
+    /// <returns>The parsed value, or the <see langword="default"/> value if enumeration or parsing failed.</returns>
+    public long TryParseLong()
+    {
+        if (MoveNext())
+        {
+            if (Int64.TryParse(Current, out long val))
+            {
+                return val;
+            }
+        }
+
+        return default;
+    }
 }

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/CsvEnumerator.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/CsvEnumerator.cs
@@ -31,7 +31,9 @@ public sealed class CsvEnumerator
     {
         Int32 start = _currentEnd + 1;
         if (!_isInitialized || start > _span.Length)
+        {
             return false;
+        }
 
         var slice = _span[start..];
         _currentStart = start;
@@ -53,12 +55,16 @@ public sealed class CsvEnumerator
             else if (curChar == '"')
             {
                 if (!escaped)
+                {
                     quoted = !quoted;
+                }
             }
             else if (curChar == ',')
             {
                 if (!quoted)
+                {
                     break;
+                }
             }
 
             escaped = false;

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/LogLine.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/LogLine.cs
@@ -37,19 +37,6 @@
             return default(int);
         }
 
-        protected static int TryParseInt(CsvEnumerator enumerator)
-        {
-            if (enumerator.MoveNext())
-            {
-                if (Int32.TryParse(enumerator.Current, out int val))
-                {
-                    return val;
-                }
-            }
-
-            return default;
-        }
-
         protected static bool TryParseBoolean(int index, string[] parts)
         {
             if (index < parts.Length)
@@ -63,33 +50,12 @@
             return default(bool);
         }
 
-        protected static bool TryParseBoolean(CsvEnumerator enumerator)
-        {
-            if (enumerator.MoveNext())
-            {
-                if (Int32.TryParse(enumerator.Current, out int val))
-                {
-                    return val != 256 && val != 999 && val > 0;
-                }
-            }
-
-            return default;
-        }
-
         protected static string? GetString(int index, string[] parts)
         {
             if (index < parts.Length)
             {
                 return parts[index].Replace("\"", string.Empty);
             }
-
-            return default;
-        }
-
-        protected static string? GetString(CsvEnumerator enumerator)
-        {
-            if (enumerator.MoveNext())
-                return enumerator.Current.ToString().Replace("\"", string.Empty);
 
             return default;
         }
@@ -107,19 +73,6 @@
             return default(DateTime);
         }
 
-        protected static DateTime TryParseDateTime(CsvEnumerator enumerator)
-        {
-            if (enumerator.MoveNext())
-            {
-                if (DateTime.TryParse(enumerator.Current, out DateTime val))
-                {
-                    return val;
-                }
-            }
-
-            return default;
-        }
-
         protected static long TryParseLong(int index, string[] parts)
         {
             if (index < parts.Length)
@@ -131,19 +84,6 @@
             }
 
             return default(long);
-        }
-
-        protected static long TryParseLong(CsvEnumerator enumerator)
-        {
-            if (enumerator.MoveNext())
-            {
-                if (Int64.TryParse(enumerator.Current, out long val))
-                {
-                    return val;
-                }
-            }
-
-            return default;
         }
     }
 }

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/LogLine.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/LogLine.cs
@@ -28,13 +28,26 @@
         {
             if (index < parts.Length)
             {
-                if(Int32.TryParse(parts[index], out int val))
+                if (Int32.TryParse(parts[index], out int val))
                 {
                     return val;
                 }
             }
 
             return default(int);
+        }
+
+        protected static int TryParseInt(CsvEnumerator enumerator)
+        {
+            if (enumerator.MoveNext())
+            {
+                if (Int32.TryParse(enumerator.Current, out int val))
+                {
+                    return val;
+                }
+            }
+
+            return default;
         }
 
         protected static bool TryParseBoolean(int index, string[] parts)
@@ -50,12 +63,33 @@
             return default(bool);
         }
 
+        protected static bool TryParseBoolean(CsvEnumerator enumerator)
+        {
+            if (enumerator.MoveNext())
+            {
+                if (Int32.TryParse(enumerator.Current, out int val))
+                {
+                    return val != 256 && val != 999 && val > 0;
+                }
+            }
+
+            return default;
+        }
+
         protected static string? GetString(int index, string[] parts)
         {
             if (index < parts.Length)
             {
                 return parts[index].Replace("\"", string.Empty);
             }
+
+            return default;
+        }
+
+        protected static string? GetString(CsvEnumerator enumerator)
+        {
+            if (enumerator.MoveNext())
+                return enumerator.Current.ToString().Replace("\"", string.Empty);
 
             return default;
         }
@@ -73,6 +107,19 @@
             return default(DateTime);
         }
 
+        protected static DateTime TryParseDateTime(CsvEnumerator enumerator)
+        {
+            if (enumerator.MoveNext())
+            {
+                if (DateTime.TryParse(enumerator.Current, out DateTime val))
+                {
+                    return val;
+                }
+            }
+
+            return default;
+        }
+
         protected static long TryParseLong(int index, string[] parts)
         {
             if (index < parts.Length)
@@ -84,6 +131,19 @@
             }
 
             return default(long);
+        }
+
+        protected static long TryParseLong(CsvEnumerator enumerator)
+        {
+            if (enumerator.MoveNext())
+            {
+                if (Int64.TryParse(enumerator.Current, out long val))
+                {
+                    return val;
+                }
+            }
+
+            return default;
         }
     }
 }

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/MessageLogLine.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/MessageLogLine.cs
@@ -22,15 +22,15 @@
 
             var result = new MessageLogLine
             {
-                Code = GetString(enumerator),
-                Flags = GetString(enumerator),
-                ParamCount = TryParseInt(enumerator),
-                Message = GetString(enumerator),
-                MessageTemplate = GetString(enumerator),
+                Code = enumerator.GetString(),
+                Flags = enumerator.GetString(),
+                ParamCount = enumerator.TryParseInt(),
+                Message = enumerator.GetString(),
+                MessageTemplate = enumerator.GetString(),
                 OriginalLine = line
             };
 
-            while (GetString(enumerator) is {} val)
+            while (enumerator.GetString() is { } val)
                 result.Params.Add(val);
 
             return result;

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/MessageLogLine.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/MessageLogLine.cs
@@ -31,7 +31,9 @@
             };
 
             while (enumerator.GetString() is { } val)
+            {
                 result.Params.Add(val);
+            }
 
             return result;
         }

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/MessageLogLine.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/LogParser/LogLines/MessageLogLine.cs
@@ -18,26 +18,20 @@
 
         public static MessageLogLine Parse(string line)
         {
-            string[] parts = line.Substring(4).Split(',');
+            var enumerator = new CsvEnumerator(line[4..]);
 
             var result = new MessageLogLine
             {
-                Code = GetString(0, parts),
-                Flags = GetString(1, parts),
-                ParamCount = TryParseInt(2, parts),
-                Message = GetString(3, parts),
-                MessageTemplate = GetString(4, parts),
+                Code = GetString(enumerator),
+                Flags = GetString(enumerator),
+                ParamCount = TryParseInt(enumerator),
+                Message = GetString(enumerator),
+                MessageTemplate = GetString(enumerator),
                 OriginalLine = line
             };
 
-            for (int i = 5; i < parts.Length; i++)
-            {
-                string? val = GetString(i, parts);
-                if (val != null)
-                {
-                    result.Params.Add(val);
-                }
-            }
+            while (GetString(enumerator) is {} val)
+                result.Params.Add(val);
 
             return result;
         }

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
@@ -74,11 +74,11 @@ namespace TheDiscDb.Tools.MakeMkv
                     var (toRedact, replacement) = msgLine.Code switch
                     {
                         // The debug file path is usually in the user's home directory
-                        "1004" => (msgLine.Params[0], "file::///redacted/by/ImportBuddy"),
+                        "1004" => (msgLine.Params[0], "***"),
                         // The drive name can sometimes contain a serial number
-                        "2003" => (msgLine.Params[1], "redacted by ImportBuddy"),
+                        "2003" => (msgLine.Params[1], "***"),
                         // The .MakeMKV folder is usually in the user's home directory
-                        "3338" => (msgLine.Params[1], "/redacted/by/ImportBuddy"),
+                        "3338" => (msgLine.Params[1], "***"),
                         // No other messages are known to contain sensitive information
                         _ => (null, ""),
                     };
@@ -95,13 +95,13 @@ namespace TheDiscDb.Tools.MakeMkv
                     if (!string.IsNullOrEmpty(driveLine.DriveName))
                     {
                         // Always redact the drive name, since it could contain a serial number
-                        line = originalLine.Replace(driveLine.DriveName, "redacted by ImportBuddy");
+                        line = originalLine.Replace(driveLine.DriveName, "***");
                         // Only keep the disc name for the active drive
                         if (driveLine.Index != driveIndex && !string.IsNullOrEmpty(driveLine.DiscName))
-                            line = line.Replace(driveLine.DiscName, "redacted by ImportBuddy");
+                            line = line.Replace(driveLine.DiscName, "***");
                         // Always redact the drive letter or path
                         if (!string.IsNullOrEmpty(driveLine.DriveLetter))
-                            line = line.Replace(driveLine.DriveLetter, "/redacted/by/ImportBuddy");
+                            line = line.Replace(driveLine.DriveLetter, "***");
                     }
                 }
 

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
@@ -84,7 +84,9 @@ namespace TheDiscDb.Tools.MakeMkv
                     };
 
                     if (toRedact is not null)
+                    {
                         line = originalLine.Replace(toRedact, replacement);
+                    }
                 }
                 else if (originalLine.StartsWith("DRV"))
                 {
@@ -96,21 +98,31 @@ namespace TheDiscDb.Tools.MakeMkv
                     {
                         // Always redact the drive name, since it could contain a serial number
                         line = originalLine.Replace(driveLine.DriveName, "***");
+
                         // Only keep the disc name for the active drive
                         if (driveLine.Index != driveIndex && !string.IsNullOrEmpty(driveLine.DiscName))
+                        {
                             line = line.Replace(driveLine.DiscName, "***");
+                        }
+
                         // Always redact the drive letter or path
                         if (!string.IsNullOrEmpty(driveLine.DriveLetter))
+                        {
                             line = line.Replace(driveLine.DriveLetter, "***");
+                        }
                     }
                 }
 
                 if (line is null)
+                {
                     // This line wasn't modified, use the original line
                     line = originalLine;
+                }
                 else
+                {
                     // Something was changed, ensure the file is overwritten
                     fileChanged = true;
+                }
 
                 output.Add(line);
             }

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
@@ -92,7 +92,7 @@ namespace TheDiscDb.Tools.MakeMkv
                     // becomes
                     // DRV:1,2,999,12,"redacted by ImportBuddy","42","/redacted/by/ImportBuddy"
                     var driveLine = DriveScanLogLine.Parse(originalLine);
-                    if (driveLine.DriveName is not null)
+                    if (!string.IsNullOrEmpty(driveLine.DriveName))
                     {
                         // Always redact the drive name, since it could contain a serial number
                         line = originalLine.Replace(driveLine.DriveName, "redacted by ImportBuddy");

--- a/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/TheDiscDb.MakeMkv/MakeMkvHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace TheDiscDb.Tools.MakeMkv
+﻿using MakeMkv;
+
+namespace TheDiscDb.Tools.MakeMkv
 {
     using System;
     using System.Collections.Generic;
@@ -42,7 +44,7 @@
                 await Task.Delay(200); // wait for file handle to be released
                 try
                 {
-                    await CleanLogs(path);
+                    await CleanLogs(driveIndex, path);
                 }
                 catch (IOException e)
                 {
@@ -51,18 +53,64 @@
             }
         }
 
-        public async Task CleanLogs(string path, CancellationToken cancellationToken = default)
+        public async Task CleanLogs(int driveIndex, string path, CancellationToken cancellationToken = default)
         {
             var output = new List<string>();
             var lines = await this.fileSystem.File.ReadAllLines(path, cancellationToken);
             bool fileChanged = false;
-            foreach (var line in lines)
+            foreach (var originalLine in lines)
             {
-                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("MSG") || line.StartsWith("DRV"))
+                // Remove empty lines from the output
+                if (originalLine == string.Empty)
                 {
                     fileChanged = true;
                     continue;
                 }
+
+                string? line = null;
+                if (originalLine.StartsWith("MSG"))
+                {
+                    var msgLine = MessageLogLine.Parse(originalLine);
+                    var (toRedact, replacement) = msgLine.Code switch
+                    {
+                        // The debug file path is usually in the user's home directory
+                        "1004" => (msgLine.Params[0], "file::///redacted/by/ImportBuddy"),
+                        // The drive name can sometimes contain a serial number
+                        "2003" => (msgLine.Params[1], "redacted by ImportBuddy"),
+                        // The .MakeMKV folder is usually in the user's home directory
+                        "3338" => (msgLine.Params[1], "/redacted/by/ImportBuddy"),
+                        // No other messages are known to contain sensitive information
+                        _ => (null, ""),
+                    };
+
+                    if (toRedact is not null)
+                        line = originalLine.Replace(toRedact, replacement);
+                }
+                else if (originalLine.StartsWith("DRV"))
+                {
+                    // DRV:1,2,999,12,"BD-ROM HL-DT-ST BDDVDRW UH12NS30 1.03","42","E:"
+                    // becomes
+                    // DRV:1,2,999,12,"redacted by ImportBuddy","42","/redacted/by/ImportBuddy"
+                    var driveLine = DriveScanLogLine.Parse(originalLine);
+                    if (driveLine.DriveName is not null)
+                    {
+                        // Always redact the drive name, since it could contain a serial number
+                        line = originalLine.Replace(driveLine.DriveName, "redacted by ImportBuddy");
+                        // Only keep the disc name for the active drive
+                        if (driveLine.Index != driveIndex && !string.IsNullOrEmpty(driveLine.DiscName))
+                            line = line.Replace(driveLine.DiscName, "redacted by ImportBuddy");
+                        // Always redact the drive letter or path
+                        if (!string.IsNullOrEmpty(driveLine.DriveLetter))
+                            line = line.Replace(driveLine.DriveLetter, "/redacted/by/ImportBuddy");
+                    }
+                }
+
+                if (line is null)
+                    // This line wasn't modified, use the original line
+                    line = originalLine;
+                else
+                    // Something was changed, ensure the file is overwritten
+                    fileChanged = true;
 
                 output.Add(line);
             }


### PR DESCRIPTION
Instead of stripping all MSG and DRV log entries, ImportBuddy now redacts log entries as described in #27. Right now, any known potentially sensitive information is replaced by "redacted by ImportBuddy". Let me know if the message should change, or if the redaction needs to be more/less aggressive.

This necessitated a change in MSG log parsing, as lines including a `,` character in the message template or any message argument broke the parser since it was a simple `string.Split(',')`. To fix this, I wrote/added `CsvEnumerator`, which is capable of parsing the comma-separated values while also taking into account quoted strings and escaped characters.

Additionally, the casing of the Linux appsettings file path was corrected.