### PR TITLE
Use "DVD" to describe DVD video quality as it may differ based on region

### DIFF
--- a/tools/ImportBuddy/source/ImportBuddy/ImportBuddy/Import/ImportTask.cs
+++ b/tools/ImportBuddy/source/ImportBuddy/ImportBuddy/Import/ImportTask.cs
@@ -311,7 +311,7 @@ public class ImportTask : IConsoleTask
         }
         else if (data.DiscFormat.Equals("DVD", StringComparison.OrdinalIgnoreCase))
         {
-            resolution = "720p";
+            resolution = "DVD";
         }
 
         string formattedTitle = $"{folderName} [{resolution}].mkv";


### PR DESCRIPTION
fixes #106
I don't think it's worth it to check the actual resolution of the video on the disc for this, so I think "DVD" is a fine descriptor for the video quality