### PR TITLE
Better disc names for select releases

### DIFF
--- a/data/movie/A Bug's Life (1998)/2020-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/A Bug's Life (1998)/2020-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/A Bug's Life (1998)/2020-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/A Bug's Life (1998)/2020-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc01.json
+++ b/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "disc-1",
-  "Name": "PEANUTS ULTIMATE COLLECTION D1",
+  "Name": "Disc 1: 1965-1973",
   "Format": "Blu-Ray",
   "ContentHash": "94EB67978B191CED80652315E8317B50",
   "Titles": [

--- a/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc02.json
+++ b/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "disc-2",
-  "Name": "PEANUTS ULTIMATE COLLECTION D2",
+  "Name": "Disc 2: 1973-1979",
   "Format": "Blu-Ray",
   "ContentHash": "AC8D20F58BCA7A52174B0EABAE027A90",
   "Titles": [

--- a/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc03.json
+++ b/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc03.json
@@ -1,7 +1,7 @@
 {
   "Index": 3,
   "Slug": "disc-3",
-  "Name": "PEANUTS ULTIMATE COLLECTION D3",
+  "Name": "Disc 3: 1980-1983",
   "Format": "Blu-Ray",
   "ContentHash": "E0896D46158E2F29B3205FEDE01F9FDE",
   "Titles": [

--- a/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc04.json
+++ b/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc04.json
@@ -1,7 +1,7 @@
 {
   "Index": 4,
   "Slug": "disc-4",
-  "Name": "PEANUTS ULTIMATE COLLECTION D4",
+  "Name": "Disc 4: 1983-1992",
   "Format": "Blu-Ray",
   "ContentHash": "426494F8C6447ACDEFA846EF4CEB46E9",
   "Titles": [

--- a/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc05.json
+++ b/data/movie/A Charlie Brown Celebration (1982)/peanuts-75th-anniversary-ultimate-tv-specials-collection-bluray/disc05.json
@@ -1,7 +1,7 @@
 {
   "Index": 5,
   "Slug": "disc-5",
-  "Name": "PEANUTS ULTIMATE COLLECTION D5",
+  "Name": "Disc 5: 1996-2011",
   "Format": "Blu-Ray",
   "ContentHash": "C796CCA1A574FB09E34D38747874E1B6",
   "Titles": [

--- a/data/movie/Aladdin (1992)/2015-diamond-edition-blu-ray/disc01.json
+++ b/data/movie/Aladdin (1992)/2015-diamond-edition-blu-ray/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Aladdin (1992)/2015-diamond-edition-blu-ray/disc02.json
+++ b/data/movie/Aladdin (1992)/2015-diamond-edition-blu-ray/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "dvd",
-  "Name": "Main Movie DVD",
+  "Name": "DVD",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Aladdin (1992)/2019-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Aladdin (1992)/2019-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Aladdin (1992)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Aladdin (1992)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Big Hero 6 (2014)/2015-collectors-edition-blu-ray/disc01.json
+++ b/data/movie/Big Hero 6 (2014)/2015-collectors-edition-blu-ray/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "ContentHash": "EA3F517886827327",
   "Titles": [

--- a/data/movie/Big Hero 6 (2014)/2015-collectors-edition-blu-ray/disc02.json
+++ b/data/movie/Big Hero 6 (2014)/2015-collectors-edition-blu-ray/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "dvd",
-  "Name": "Main Movie DVD",
+  "Name": "DVD",
   "Format": "DVD",
   "ContentHash": "25835400F6D80852",
   "Titles": [

--- a/data/movie/Big Hero 6 (2014)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Big Hero 6 (2014)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "ContentHash": "F65B78B81EC57654",
   "Titles": [

--- a/data/movie/Breakfast at Tiffany's (1961)/2019-7-movie-collection/disc01.json
+++ b/data/movie/Breakfast at Tiffany's (1961)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "breakfast-at-tiffanys",
-  "Name": "BREAKFAST_AT_TIFFANYS",
+  "Name": "Breakfast at Tiffany's",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Coco (2017)/2018-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Coco (2017)/2018-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "ContentHash": "2476050577ED68347F4F3C2E131FB98C",
   "Titles": [

--- a/data/movie/Coco (2017)/2018-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Coco (2017)/2018-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "ContentHash": "FA45045411527EE3EC7ABFBF5375C608",
   "Titles": [

--- a/data/movie/Finding Nemo (2003)/2019-best-buy-steelbook-4k/disc01.json
+++ b/data/movie/Finding Nemo (2003)/2019-best-buy-steelbook-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "ContentHash": "846A372954E18DE8E4E44A2CF7385415",
   "Titles": [

--- a/data/movie/Finding Nemo (2003)/2019-best-buy-steelbook-4k/disc02.json
+++ b/data/movie/Finding Nemo (2003)/2019-best-buy-steelbook-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "ContentHash": "AEB22A2628E2658DC5F169AF1DE13D59",
   "Titles": [

--- a/data/movie/Frozen (2013)/2019-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Frozen (2013)/2019-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Frozen (2013)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Frozen (2013)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Funny Face (1957)/2019-7-movie-collection/disc01.json
+++ b/data/movie/Funny Face (1957)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "funny-face",
-  "Name": "FUNNY_FACE_CC_DISC_1",
+  "Name": "Funny Face",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Garfield (2004)/2004-dvd/disc01.json
+++ b/data/movie/Garfield (2004)/2004-dvd/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "dvd",
-  "Name": "GARFIELDTHEMOVIE",
+  "Name": "DVD",
   "Format": "DVD",
   "ContentHash": "68AF7D5C5EEB9DBFB3DED62B02B1C5D2",
   "Titles": [

--- a/data/movie/Garfield's Pet Force (2009)/2009-dvd/disc01.json
+++ b/data/movie/Garfield's Pet Force (2009)/2009-dvd/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "dvd",
-  "Name": "GARFIELD_PETFORCE",
+  "Name": "DVD",
   "Format": "DVD",
   "ContentHash": "4511B2A657A6662011049E4653C8F479",
   "Titles": [

--- a/data/movie/Jack Frost (1998)/2008-dvd/disc01.json
+++ b/data/movie/Jack Frost (1998)/2008-dvd/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "dvd",
-  "Name": "Main Title DVD",
+  "Name": "DVD",
   "Format": "DVD",
   "ContentHash": "C0FF3B6EFA44A2853F49F960D751F78D",
   "Titles": [

--- a/data/movie/Maleficent Mistress of Evil (2019)/2020-target-exclusive-4k/disc01.json
+++ b/data/movie/Maleficent Mistress of Evil (2019)/2020-target-exclusive-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "ContentHash": "A7DA9FF5030D52ABDDDCF4FE2814B4C7",
   "Titles": [

--- a/data/movie/Maleficent Mistress of Evil (2019)/2020-target-exclusive-4k/disc02.json
+++ b/data/movie/Maleficent Mistress of Evil (2019)/2020-target-exclusive-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "ContentHash": "12A378F46619D2C56FFDC1736B039EE5",
   "Titles": [

--- a/data/movie/Moana (2016)/2016-best-buy-steelbook-4k/disc01.json
+++ b/data/movie/Moana (2016)/2016-best-buy-steelbook-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "ContentHash": "71ECA356EAE78E026DA81CE3CAD9E4D0",
   "Titles": [

--- a/data/movie/Moana (2016)/2016-best-buy-steelbook-4k/disc02.json
+++ b/data/movie/Moana (2016)/2016-best-buy-steelbook-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "ContentHash": "278590E7C8D7D22C20B1F9A8675515B7",
   "Titles": [

--- a/data/movie/My Fair Lady (1964)/2019-7-movie-collection/disc01.json
+++ b/data/movie/My Fair Lady (1964)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "my-fair-lady",
-  "Name": "MY_FAIR_LADY",
+  "Name": "My Fair Lady",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Onward (2020)/2020-target-exclusive-4k/disc01.json
+++ b/data/movie/Onward (2020)/2020-target-exclusive-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Onward (2020)/2020-target-exclusive-4k/disc02.json
+++ b/data/movie/Onward (2020)/2020-target-exclusive-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Pacific Rim (2013)/2013-3d-blu-ray-mx/disc01.json
+++ b/data/movie/Pacific Rim (2013)/2013-3d-blu-ray-mx/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Paris When It Sizzles (1964)/2019-7-movie-collection/disc01.json
+++ b/data/movie/Paris When It Sizzles (1964)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "paris-when-it-sizzles",
-  "Name": "PARIS_WHEN_IT_SIZZLES",
+  "Name": "Paris When It Sizzles",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Roman Holiday (1953)/2019-7-movie-collection/disc01.json
+++ b/data/movie/Roman Holiday (1953)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "roman-holiday",
-  "Name": "ROMAN_HOLIDAY",
+  "Name": "Roman Holiday",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Sabrina (1954)/2019-7-movie-collection/disc01.json
+++ b/data/movie/Sabrina (1954)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "sabrina",
-  "Name": "SABRINA",
+  "Name": "Sabrina",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Sixty Glorious Years (1938)/2019-blu-ray/disc01.json
+++ b/data/movie/Sixty Glorious Years (1938)/2019-blu-ray/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "SIXTY GLORIOUS YEARS",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "ContentHash": "A201317E14EA034295FF88741CE14837",
   "Titles": [

--- a/data/movie/Tangled (2010)/2019-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Tangled (2010)/2019-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Tangled (2010)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Tangled (2010)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/The Lion King (2019)/2019-target-exclusive-4k/disc01.json
+++ b/data/movie/The Lion King (2019)/2019-target-exclusive-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/The Lion King (2019)/2019-target-exclusive-4k/disc02.json
+++ b/data/movie/The Lion King (2019)/2019-target-exclusive-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Toy Story (1995)/2019-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Toy Story (1995)/2019-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Toy Story (1995)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Toy Story (1995)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Toy Story 2 (1999)/2019-ultimate-collectors-edition-4K/disc01.json
+++ b/data/movie/Toy Story 2 (1999)/2019-ultimate-collectors-edition-4K/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Toy Story 2 (1999)/2019-ultimate-collectors-edition-4K/disc02.json
+++ b/data/movie/Toy Story 2 (1999)/2019-ultimate-collectors-edition-4K/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Toy Story 3 (2010)/2019-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Toy Story 3 (2010)/2019-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Toy Story 3 (2010)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Toy Story 3 (2010)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Toy Story 4 (2019)/2019-target-exclusive-4k/disc01.json
+++ b/data/movie/Toy Story 4 (2019)/2019-target-exclusive-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/Toy Story 4 (2019)/2019-target-exclusive-4k/disc02.json
+++ b/data/movie/Toy Story 4 (2019)/2019-target-exclusive-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Up (2009)/2020-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Up (2009)/2020-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Up (2009)/2020-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Up (2009)/2020-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/WALL E (2008)/2020-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/WALL E (2008)/2020-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/WALL E (2008)/2020-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/WALL E (2008)/2020-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/movie/War and Peace (1956)/2019-7-movie-collection/disc01.json
+++ b/data/movie/War and Peace (1956)/2019-7-movie-collection/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "war-and-peace",
-  "Name": "WAR_AND_PEACE",
+  "Name": "War and Peace",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/movie/Zootopia (2016)/2019-ultimate-collectors-edition-4k/disc01.json
+++ b/data/movie/Zootopia (2016)/2019-ultimate-collectors-edition-4k/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "blu-ray",
-  "Name": "Main Movie Blu-ray",
+  "Name": "Blu-ray",
   "Format": "Blu-Ray",
   "Titles": [
     {

--- a/data/movie/Zootopia (2016)/2019-ultimate-collectors-edition-4k/disc02.json
+++ b/data/movie/Zootopia (2016)/2019-ultimate-collectors-edition-4k/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "4k",
-  "Name": "Main Movie 4K",
+  "Name": "4K",
   "Format": "UHD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc01.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc01.json
@@ -1,7 +1,7 @@
 {
   "Index": 1,
   "Slug": "season-1-disc-1",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S1",
+  "Name": "Season 1 Disc 1",
   "Format": "DVD",
   "ContentHash": "280D623572AC6FA9B603D32D320869DE",
   "Titles": [

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc02.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc02.json
@@ -1,7 +1,7 @@
 {
   "Index": 2,
   "Slug": "season-1-disc-2",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S1",
+  "Name": "Season 1 Disc 2",
   "Format": "DVD",
   "ContentHash": "47D944721D32EF1B59EF6034F079EC39",
   "Titles": [

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc03.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc03.json
@@ -1,7 +1,7 @@
 {
   "Index": 3,
   "Slug": "season-1-disc-3",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S1",
+  "Name": "Season 1 Disc 3",
   "Format": "DVD",
   "ContentHash": "6019B714447437703281209DD660F0A8",
   "Titles": [

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc04.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc04.json
@@ -1,7 +1,7 @@
 {
   "Index": 4,
   "Slug": "season-1-disc-4",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S1",
+  "Name": "Season 1 Disc 4",
   "Format": "DVD",
   "ContentHash": "593645B7089C5FB930DF54D44A14F4DB",
   "Titles": [

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc05.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc05.json
@@ -1,7 +1,7 @@
 {
   "Index": 5,
   "Slug": "season-2-disc-1",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S2_D1",
+  "Name": "Season 2 Disc 1",
   "Format": "DVD",
   "ContentHash": "FFCD989FFD87AADA57B0F79D75342220",
   "Titles": [

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc06.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc06.json
@@ -1,7 +1,7 @@
 {
   "Index": 6,
   "Slug": "season-2-disc-2",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S2_D2",
+  "Name": "Season 2 Disc 2",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc07.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc07.json
@@ -1,7 +1,7 @@
 {
   "Index": 7,
   "Slug": "season-2-disc-3",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S4_D3",
+  "Name": "Season 2 Disc 3",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc08.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc08.json
@@ -1,7 +1,7 @@
 {
   "Index": 8,
   "Slug": "season-2-disc-4",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S2_D4",
+  "Name": "Season 2 Disc 4",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc09.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc09.json
@@ -1,7 +1,7 @@
 {
   "Index": 9,
   "Slug": "season-3-disc-1",
-  "Name": "UNDEFINED",
+  "Name": "Season 3 Disc 1",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc10.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc10.json
@@ -1,7 +1,7 @@
 {
   "Index": 10,
   "Slug": "season-3-disc-2",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S3_D2",
+  "Name": "Season 3 Disc 2",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc11.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc11.json
@@ -1,7 +1,7 @@
 {
   "Index": 11,
   "Slug": "season-3-disc-3",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S3_D3",
+  "Name": "Season 3 Disc 3",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc12.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc12.json
@@ -1,7 +1,7 @@
 {
   "Index": 12,
   "Slug": "season-3-disc-4",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S3_D4",
+  "Name": "Season 3 Disc 4",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc13.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc13.json
@@ -1,7 +1,7 @@
 {
   "Index": 13,
   "Slug": "season-4-disc-1",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S4D1",
+  "Name": "Season 4 Disc 1",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc14.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc14.json
@@ -1,7 +1,7 @@
 {
   "Index": 14,
   "Slug": "season-4-disc-2",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S4D2",
+  "Name": "Season 4 Disc 2",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc15.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc15.json
@@ -1,7 +1,7 @@
 {
   "Index": 15,
   "Slug": "season-4-disc-3",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S4D3",
+  "Name": "Season 4 Disc 3",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc16.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc16.json
@@ -1,7 +1,7 @@
 {
   "Index": 16,
   "Slug": "season-5-disc-1",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S5D1",
+  "Name": "Season 5 Disc 1",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc17.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc17.json
@@ -1,7 +1,7 @@
 {
   "Index": 17,
   "Slug": "season-5-disc-2",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S5D2",
+  "Name": "Season 5 Disc 2",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc18.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc18.json
@@ -1,7 +1,7 @@
 {
   "Index": 18,
   "Slug": "season-5-disc-3",
-  "Name": "SABRINA_THE_TEENAGE_WITCH_S5D3",
+  "Name": "Season 5 Disc 3",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc19.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc19.json
@@ -1,7 +1,7 @@
 {
   "Index": 19,
   "Slug": "season-6-disc-1",
-  "Name": "SABRINA_6_D1",
+  "Name": "Season 6 Disc 1",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc20.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc20.json
@@ -1,7 +1,7 @@
 {
   "Index": 20,
   "Slug": "season-6-disc-2",
-  "Name": "SABRINA_6_D2",
+  "Name": "Season 6 Disc 2",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc21.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc21.json
@@ -1,7 +1,7 @@
 {
   "Index": 21,
   "Slug": "season-6-disc-3",
-  "Name": "SABRINA_6_D3",
+  "Name": "Season 6 Disc 3",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc22.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc22.json
@@ -1,7 +1,7 @@
 {
   "Index": 22,
   "Slug": "season-7-disc-1",
-  "Name": "SABRINA_S7_D1",
+  "Name": "Season 7 Disc 1",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc23.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc23.json
@@ -1,7 +1,7 @@
 {
   "Index": 23,
   "Slug": "season-7-disc-2",
-  "Name": "SABRINA_S7_D2",
+  "Name": "Season 7 Disc 2",
   "Format": "DVD",
   "Titles": [
     {

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc24-summary.txt
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc24-summary.txt
@@ -51,7 +51,7 @@ Segment map: 1-6
 File name: Sabrina, the Teenage Witch.S07.E21.What a Witch Wants & Soul Mates.mkv
 
 Name: Sabrina Goes To Rome
-Type: Extra
+Type: Short
 Year: 1998
 Comment: B5
 Source title ID: 11

--- a/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc24.json
+++ b/data/series/Sabrina, the Teenage Witch (1996)/2020-complete-series/disc24.json
@@ -1,7 +1,7 @@
 {
   "Index": 24,
   "Slug": "season-7-disc-3",
-  "Name": "SABRINA_S7_D3",
+  "Name": "Season 7 Disc 3 + Sabrina Goes To Rome",
   "Format": "DVD",
   "Titles": [
     {
@@ -207,7 +207,7 @@
       "DisplaySize": "3.1 GB",
       "Item": {
         "Title": "Sabrina Goes To Rome",
-        "Type": "Extra",
+        "Type": "Short",
         "Chapters": []
       },
       "Tracks": [

--- a/data/sets/Peanuts 75th Anniversary Ultimate TV Specials Collection Blu-ray (2025)/boxset.json
+++ b/data/sets/Peanuts 75th Anniversary Ultimate TV Specials Collection Blu-ray (2025)/boxset.json
@@ -15,35 +15,35 @@
   "Discs": [
     {
       "Index": 1,
-      "Name": "Disc 1",
+      "Name": "Disc 1: 1965-1973",
       "Format": "Blu-Ray",
       "Slug": "disc-1",
       "TitleSlug": "a-charlie-brown-christmas-1965"
     },
     {
       "Index": 2,
-      "Name": "Disc 2",
+      "Name": "Disc 2: 1973-1979",
       "Format": "Blu-Ray",
       "Slug": "disc-2",
       "TitleSlug": "a-charlie-brown-thanksgiving-1973"
     },
     {
       "Index": 3,
-      "Name": "Disc 3",
+      "Name": "Disc 3: 1980-1983",
       "Format": "Blu-Ray",
       "Slug": "disc-3",
       "TitleSlug": "shes-a-good-skate-charlie-brown-1980"
     },
     {
       "Index": 4,
-      "Name": "Disc 4",
+      "Name": "Disc 4: 1983-1992",
       "Format": "Blu-Ray",
       "Slug": "disc-4",
       "TitleSlug": "what-have-we-learned-charlie-brown-1983"
     },
     {
       "Index": 5,
-      "Name": "Disc 5",
+      "Name": "Disc 5: 1996-2011",
       "Format": "Blu-Ray",
       "Slug": "disc-5",
       "TitleSlug": "its-spring-training-charlie-brown-1996"


### PR DESCRIPTION
- Used properly descriptive names for many of my own releases where I used the disc label
- This might be subjective, but I felt the prefix "Main Movie" on many releases in the DB was redundant, especially when there is no bonus features disc, so I removed instances of those