### PR TITLE
Fix CI crash when contribution PR is merged before the run starts

### DIFF
--- a/housekeeping/appliances/files.ts
+++ b/housekeeping/appliances/files.ts
@@ -4,18 +4,49 @@ import { Octokit } from "octokit";
 const event = process.env.GITHUB_EVENT_NAME;
 const repoFull = process.env.GITHUB_REPOSITORY;
 
+/**
+ * Resolve the pull request number for the current run.
+ *
+ * Reads it from the event payload (`pull_request.number`) which is reliable
+ * even when the PR has already been merged/closed by the time the run starts.
+ * In that case the checkout falls back to the base branch and
+ * `GITHUB_REF_NAME` becomes e.g. `main` (not `<pr_number>/merge`), so parsing
+ * the ref name yields `NaN` and the API call blows up on `pulls/NaN/files`.
+ * Falls back to parsing `GITHUB_REF_NAME` for local testing.
+ */
+const getPullRequestNumber = async (): Promise<number | undefined> => {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    try {
+      const payload = await Bun.file(eventPath).json();
+      const num = payload?.pull_request?.number;
+      if (typeof num === "number" && Number.isInteger(num)) return num;
+    } catch {
+      // fall through to ref-name parsing
+    }
+  }
+
+  // > For pull requests, the format is <pr_number>/merge.
+  const refNumber = Number(process.env.GITHUB_REF_NAME?.split("/")[0]);
+  return Number.isInteger(refNumber) ? refNumber : undefined;
+};
+
 export const getModifiedFiles = async (): Promise<string[]> => {
   if (event !== "pull_request") return [];
+
+  const prNumber = await getPullRequestNumber();
+  if (prNumber === undefined) {
+    console.warn(
+      "Could not determine the pull request number; skipping file scoping.",
+    );
+    return [];
+  }
 
   // GITHUB_TOKEN not actually required while in an action; this is for local
   // testing with private repos
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
   // biome-ignore lint/style/noNonNullAssertion: value from GH
   const [owner, repo] = repoFull!.split("/") as [string, string];
-
-  // > For pull requests, the format is <pr_number>/merge.
-  // biome-ignore lint/style/noNonNullAssertion: value from GH
-  const prNumber = Number(process.env.GITHUB_REF_NAME!.split("/")[0]);
 
   const response = await octokit.rest.pulls.listFiles({
     owner,


### PR DESCRIPTION
## Problem

Contribution PRs (created and auto-merged by contributionbuddy) sometimes produce a failed `Verify file integrity` run, e.g. [run 29209262289](https://github.com/TheDiscDb/data/actions/runs/29209262289):

```
HttpError: Not Found
url: "https://api.github.com/repos/TheDiscDb/data/pulls/NaN/files?per_page=3000"
```

## Root cause

When a PR is merged/closed **before** its `pull_request` CI run starts, the `refs/pull/<n>/merge` ref no longer exists, so `actions/checkout` falls back to the base branch and `GITHUB_REF_NAME` becomes `main` instead of `<pr_number>/merge`. The appliance parsed the PR number as `Number(GITHUB_REF_NAME.split('/')[0])` → `Number('main')` → `NaN`, crashing on `pulls/NaN/files`.

Runs where the PR was not yet merged checked out `refs/pull/<n>/merge` and passed — which is why the failure was intermittent.

## Fix

Resolve the PR number from the event payload (`pull_request.number` via `GITHUB_EVENT_PATH`), which is reliable regardless of the checked-out ref. Falls back to parsing `GITHUB_REF_NAME` for local testing, and returns no modified files (instead of crashing) if the number cannot be determined.
