### PR TITLE
Announce ImportBuddy retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# thediscdb-data
-Source data for thediscdb
+# TheDiscDb Data
+
+Source data for [TheDiscDb](https://thediscdb.com).
+
+## Contributing
+
+Use the supported website contribution and edit-suggestion workflows:
+
+- [Contribution guide](https://thediscdb.com/help/contributing)
+- [Start a contribution](https://thediscdb.com/contribute)
+
+The complete disc-scanning flow currently requires Chrome or Edge.
+
+## ImportBuddy retirement
+
+ImportBuddy is deprecated and unsupported. Its downloads and source will be
+removed on September 13, 2026.
+
+See the [retirement announcement](https://github.com/orgs/TheDiscDb/discussions/629)
+for details. This retirement does not change the repository's pull-request
+permissions; any later contribution-policy change will be announced separately.

--- a/docs/importbuddy-retired.md
+++ b/docs/importbuddy-retired.md
@@ -11,7 +11,7 @@ Use the supported website workflows instead:
 
 The complete disc-scanning flow currently requires Chrome or Edge. Broader
 browser support is tracked in
-[issue #177](https://github.com/TheDiscDb/data/issues/177).
+[TheDiscDb/web issue #61](https://github.com/TheDiscDb/web/issues/61).
 
 See the
 [retirement announcement](https://github.com/orgs/TheDiscDb/discussions/629)

--- a/docs/importbuddy-retired.md
+++ b/docs/importbuddy-retired.md
@@ -1,0 +1,21 @@
+# ImportBuddy retirement
+
+ImportBuddy is deprecated and unsupported. Its GitHub releases, associated
+version tags, source code, and publishing workflow will be removed on
+September 13, 2026.
+
+Use the supported website workflows instead:
+
+- [Contribution guide](https://thediscdb.com/help/contributing)
+- [Start a contribution](https://thediscdb.com/contribute)
+
+The complete disc-scanning flow currently requires Chrome or Edge. Broader
+browser support is tracked in
+[issue #177](https://github.com/TheDiscDb/data/issues/177).
+
+See the
+[retirement announcement](https://github.com/orgs/TheDiscDb/discussions/629)
+for the reasons, timeline, and migration guidance.
+
+This retirement does not change the data repository's pull-request permissions
+or decide how existing pull requests will be handled.


### PR DESCRIPTION
## Summary

- direct contributors to the supported website contribution workflows
- announce that ImportBuddy is unsupported and scheduled for removal on September 13, 2026
- preserve a durable retirement page and clarify that pull-request policy is unchanged in this phase

Discussion: https://github.com/orgs/TheDiscDb/discussions/629

## Scope

This PR does not remove ImportBuddy source, releases, tags, or change repository pull-request permissions. Destructive removal remains scheduled for after the notice period.